### PR TITLE
Add Mod Menu dependency for Fabric

### DIFF
--- a/buildSrc/src/main/groovy/multiloader-common.gradle
+++ b/buildSrc/src/main/groovy/multiloader-common.gradle
@@ -42,6 +42,10 @@ repositories {
         name = 'BlameJared'
         url = 'https://maven.blamejared.com'
     }
+    maven {
+        name = 'TerraformersMC'
+        url = 'https://maven.terraformersmc.com/'
+    }
 }
 
 // Declare capabilities on the outgoing configurations.
@@ -90,6 +94,7 @@ processResources {
             'minecraft_version_range'      : minecraft_version_range,
             'fabric_version'               : fabric_version,
             'fabric_loader_version'        : fabric_loader_version,
+            'mod_menu_version'            : mod_menu_version,
             'mod_name'                     : mod_name,
             'mod_author'                   : mod_author,
             'mod_id'                       : mod_id,

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     }
     modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_version}"
+    modCompileOnly "com.terraformersmc:modmenu:${mod_menu_version}"
 }
 
 loom {

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -30,6 +30,7 @@
         "java": ">=${java_version}"
     },
     "suggests": {
+        "modmenu": ">=${mod_menu_version}",
         "another-mod": "*"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,6 +25,7 @@ parchment_version=2025.04.19
 # Fabric
 fabric_version=0.119.5+1.21.5
 fabric_loader_version=0.16.10
+mod_menu_version=15.0.0-beta.3
 
 # Forge
 forge_version=55.0.1

--- a/scripts/set_minecraft_version.py
+++ b/scripts/set_minecraft_version.py
@@ -103,6 +103,17 @@ def get_fabric_api_version(mc):
         return None
 
 
+def get_mod_menu_version(mc):
+    query = urllib.parse.quote(f'["{mc}"]', safe="")
+    url = f"https://api.modrinth.com/v2/project/modmenu/version?game_versions={query}"
+    try:
+        versions = json.loads(fetch_url_text(url))
+        latest = max(versions, key=lambda v: v["date_published"])
+        return latest["version_number"]
+    except Exception:
+        return None
+
+
 def get_forge_version(mc):
     url = f"https://files.minecraftforge.net/net/minecraftforge/forge/index_{mc}.html"
     try:
@@ -124,6 +135,7 @@ def collect_versions(mc):
         "parchment_version": get_parchment_version(mc),
         "fabric_loader_version": get_fabric_loader_version(mc),
         "fabric_version": get_fabric_api_version(mc),
+        "mod_menu_version": get_mod_menu_version(mc),
         "forge_version": get_forge_version(mc),
     }
 
@@ -148,6 +160,7 @@ def apply_versions(props_path: Path, mc: str, versions: dict):
         "parchment_version": versions.get("parchment_version"),
         "fabric_loader_version": versions.get("fabric_loader_version"),
         "fabric_version": versions.get("fabric_version"),
+        "mod_menu_version": versions.get("mod_menu_version"),
         "forge_version": versions.get("forge_version"),
         "neoforge_version": versions.get("neoforge_version"),
         "game_versions": mc,


### PR DESCRIPTION
## Summary
- set up a TerraformersMC Maven repo
- expose `mod_menu_version` to resource expansion
- depend on Mod Menu in the Fabric build
- declare Mod Menu in `fabric.mod.json`
- support fetching Mod Menu versions via the setup script
- record a default Mod Menu version in `gradle.properties`
- make Mod Menu optional

## Testing
- `./gradlew --version`
- `./gradlew build` *(fails: lock waiting issue)*

------
https://chatgpt.com/codex/tasks/task_e_6857e87f5bac8331a70f1cb62cf14f77